### PR TITLE
Keyword arguments support?

### DIFF
--- a/spec/after_do_spec.rb
+++ b/spec/after_do_spec.rb
@@ -23,6 +23,9 @@ describe AfterDo do
       def two(param1, param2)
         param2
       end
+
+      def kwargs(defd: :default, reqd:)
+      end
     end
   end
 
@@ -157,6 +160,11 @@ describe AfterDo do
         @dummy_class.send callback_adder,  :two do mockie.call_method end
         dummy_instance.two 5, 8
       end
+
+      it 'can handle methods with keyword arguments' do
+        @dummy_class.send callback_adder, :kwargs do mockie.call_method end
+        dummy_instance.kwargs defd: :def, reqd: :req
+      end
     end
 
     describe 'with parameters for the given block' do
@@ -170,6 +178,14 @@ describe AfterDo do
         expect(mockie).to receive(:call_method).with(5, 8)
         @dummy_class.send callback_adder,  :two do |i, j| mockie.call_method i, j end
         dummy_instance.two 5, 8
+      end
+
+      it 'can handle keyword arguments' do
+        expect(mockie).to receive(:call_method).with(defd: :def, reqd: :req)
+        @dummy_class.send callback_adder, :kwargs do |args|
+          mockie.call_method defd: args[:defd], reqd: args[:reqd]
+        end
+        dummy_instance.kwargs defd: :def, reqd: :req
       end
     end
 


### PR DESCRIPTION
Is there a chance for after_do to have keyword arguments support?

I was hoping for something like

``` ruby
@dummy_class.send callback_adder, :kwargs do |defd:, reqd:|
  mockie.call_method defd: defd, reqd: reqd
end
```

but I think the invisible `object` argument at the end makes it blow up (you can’t have non-kwargs after kwargs).

The best I could do is to fake them via a `Hash` access (as in this PR), which might be the best that can be done while preserving the optional `object`.

Note that this PR probably won’t even build outside of MRI 2.1 and 2.2 – once the decision whether/how to support kwargs is made I can try wiring the specs so that kwarg-related ones are only ran on kwarg-capable Rubies.
