### PR TITLE
Send method name to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ And finally if you want to access method name inside the callback:
 MyClass.after :two_arg_method do |arg1, arg2, obj, method| something(arg1, arg2, obj, method) end
 ```
 
+You can access returned value in `after` callback as the last argument.
+```ruby
+MyClass.after :two_arg_method do |args*, obj| result = args.last end
+```
+
 If you do not want to get a hold of the method arguments or the object, then you can just don't care about the block parameters :-)
 
 Check out the [getting a hold sample](https://github.com/PragTob/after_do/blob/master/samples/getting_a_hold.rb) for more.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install after_do
-    
+
 And then you have to require the gem before you can use it:
 
     require 'after_do'
@@ -99,6 +99,12 @@ Of course you can get a hold of the method arguments and the object:
 
 ```ruby
 MyClass.after :two_arg_method do |arg1, arg2, obj| something(arg1, arg2, obj) end
+```
+
+And finally if you want to access method name inside the callback:
+
+```ruby
+MyClass.after :two_arg_method do |arg1, arg2, obj, method| something(arg1, arg2, obj, method) end
 ```
 
 If you do not want to get a hold of the method arguments or the object, then you can just don't care about the block parameters :-)
@@ -174,7 +180,7 @@ after_do works with modules just like it works with classes from version 0.3.0 o
 class MyClass
   include MyModule
   # ....
-end 
+end
 
 MyModule.extend AfterDo
 MyModule.after :some_method do cool_stuff end

--- a/lib/after_do.rb
+++ b/lib/after_do.rb
@@ -97,7 +97,7 @@ module AfterDo
     define_method method do |*args|
       callback_klazz.send(:_after_do_execute_callbacks, :before, method, self, *args)
       return_value = send(alias_name, *args)
-      callback_klazz.send(:_after_do_execute_callbacks, :after, method, self, *args)
+      callback_klazz.send(:_after_do_execute_callbacks, :after, method, self, *args, return_value)
       return_value
     end
   end

--- a/lib/after_do.rb
+++ b/lib/after_do.rb
@@ -110,7 +110,7 @@ module AfterDo
 
   def _after_do_execute_callback(block, method, object, *args)
     begin
-      block.call(*args, object)
+      block.call(*args, object, method)
     rescue Exception => error
       raise CallbackError, "A #{error.class}: #{error.message} was raised during an after_do callback block for method '#{method}' on the instance #{self.inspect} with the following arguments: #{args.join(', ')} defined in the file #{block.source_location[0]} in line #{block.source_location[1]}. This is the backtrace of the #{error.class}: \n #{error.backtrace.join("\n")}"
     end


### PR DESCRIPTION
It can be useful to know which method entered after/before callback. Easier than solving it inside the block code is simply adding it as another parameter to `_after_do_execute_callback `.