### PR TITLE
Hand method name and (for after) return value to the block.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-  - rbx-2
-  - rbx-3.19
   - jruby
   - 1.9.3
   - 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 0.4.0 (unreleased)
+
+* Hand new arguments to callbacks, namely method name and return value (for after). New Order of block arguments for before is: `arguments, method_name, object`, for after it is: `arguments, method_name, return_value, object`. To migrate to this version you need to change blocks that either use `*args` and then access `args` or calls that do `arg_1, arg_2, object` as the third argument is now the method name. You can change them to `arg_1, arg_2, *, object`.
+
+## 0.3.1 (March 27, 2014)
+
+* improve error reporting
+* run warning free with -w
+
+## 0.3.0 (January 19, 2014)
+
+* Work properly with inheritance (callbacks are just called if `super` is really invoked)
+* Work properly with modules (callbacks on module methods are executed when the methods are called)

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rubysl', platform: :rbx
-gem 'rubinius-coverage', platform: :rbx
-gem 'psych', platform: :rbx
-gem 'json', platform: :rbx
-
 gem 'bundler'
 gem 'rake'
 gem 'rspec'

--- a/README.md
+++ b/README.md
@@ -307,7 +307,9 @@ A use case I feel this is particularly made for is redrawing. That's what we use
 
 ## Does it work with Ruby interpreter X?
 
-Thanks to the awesome [travis CI](https://travis-ci.org/) the specs are run with CRuby 1.9.3, 2.0, 2.1, 2.2 the latest jruby and rubinius releases. So in short, this should work with all of them and is aimed at doing so :-)
+Thanks to the awesome [travis CI](https://travis-ci.org/) the specs are run with CRuby 1.9.3, 2.0, 2.1, 2.2, 2.3 and the latest JRuby releases. It _should_ work with rubinius, but some problems lead me to remove it from the build matrix.
+
+So in short, this should work with all of them and is aimed at doing so :-)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ If the class extends `AfterDo` you can simply do this by
 
 ```
 MyClass.after :some_method do whatever_you_want end
+# you can also do before
+MyClass.before :a_method do so_much end
 ```
 
 Some facts about after_do:
@@ -79,7 +81,7 @@ dog2.bark
 # I just heard a dog bark!
 ```
 
-### Getting a hold of the method arguments and the object
+### Getting a hold of the method arguments, the object and more!
 
 With after_do both the arguments to the method you are attaching the callback to and the object for which the callback is executed are passed into the callback block.
 
@@ -89,30 +91,47 @@ So if you have a method that takes two arguments you can get those like this:
 MyClass.after :two_arg_method do |argument_one, argument_2| something end
 ```
 
-The object itself is passed in as the last block argument, so if you just care about the object you can do:
+The method name is passed in as the third argument:
+
+```ruby
+MyClass.before :two_arg_method do |argument_one, argument_2, method_name|
+  something
+end
+```
+
+The method name is passed for convenience if you do logging for instance. If you start doing `if` or `case` on the method name, rather think about if you should use different callbacks for the different methods.
+
+Another argument that is passed in, but only for `after` is the return value of the method so you can do:
+
+```ruby
+MyClass.after :two_arg_method do |arg1, arg2, name, return_value|
+  report return_value
+end
+```
+
+The object itself is passed in as the last block argument finally so all arguments together are:
+
+```ruby
+MyClass.after :method do |arg1, arg2, name, return_value, object|
+  magic
+end
+
+# remember before doesn't have the return value
+MyClass.before :method do |arg1, arg2, name, object|
+  other_magic
+end
+```
+
+Why this order of arguments? Well at first there are the arguments related to the method itself (arguments, name and optional return value) and then there is the object.
+
+Of course you can just grab the object, if you're not interested in all the method related data, by using the splat operator to _soak up_ all the other arguments:
 
 ```ruby
 MyClass.after :two_arg_method do |*, obj| fancy_stuff(obj) end
 ```
 
-Of course you can get a hold of the method arguments and the object:
 
-```ruby
-MyClass.after :two_arg_method do |arg1, arg2, obj| something(arg1, arg2, obj) end
-```
-
-And finally if you want to access method name inside the callback:
-
-```ruby
-MyClass.after :two_arg_method do |arg1, arg2, obj, method| something(arg1, arg2, obj, method) end
-```
-
-You can access returned value in `after` callback as the last argument.
-```ruby
-MyClass.after :two_arg_method do |args*, obj| result = args.last end
-```
-
-If you do not want to get a hold of the method arguments or the object, then you can just don't care about the block parameters :-)
+If you do not want to get a hold of the method arguments or the object, then you can just don't care about the block parameters and can leave them out :-)
 
 Check out the [getting a hold sample](https://github.com/PragTob/after_do/blob/master/samples/getting_a_hold.rb) for more.
 
@@ -263,17 +282,6 @@ return_value
 
 To do this some helper methods are defined in the AfterDo module. As classes have to extend the AfterDo module all the methods that you are not supposed to call yourself are prefixed with `_after_do_` to minimize the risk of method name clashes. The only not prefixed method are `after`, `before` and `remove_all_callbacks`.
 
-
-## Is there a before method?
-
-Yes. It works just like the `after` method, but the callbacks are executed before the original method is called. You can also mix and match before and after calls.
-
-```ruby
-MyClass.before :a_method do so_much end
-```
-
-Check out the [before sample](https://github.com/PragTob/after_do/blob/master/samples/before.rb).
-
 ### Method granularity
 
 after_do works on the granularity of methods. That means that you can only attach callbacks to methods. This is no problem however, since if it's your code you can always define new methods. E.g. if you want to attach callbacks to the end of some operation that happens in the middle of a method just define a new method for that piece of code.
@@ -299,7 +307,7 @@ A use case I feel this is particularly made for is redrawing. That's what we use
 
 ## Does it work with Ruby interpreter X?
 
-Thanks to the awesome [travis CI](https://travis-ci.org/) the specs are run with MRI 1.9.3, 2.0, 2.1, the latest jruby and rubinius releases in 1.9 mode. So in short, this should work with all of them and is aimed at doing so :-)
+Thanks to the awesome [travis CI](https://travis-ci.org/) the specs are run with CRuby 1.9.3, 2.0, 2.1, 2.2 the latest jruby and rubinius releases. So in short, this should work with all of them and is aimed at doing so :-)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ And finally if you want to access method name inside the callback:
 MyClass.after :two_arg_method do |arg1, arg2, obj, method| something(arg1, arg2, obj, method) end
 ```
 
+You can access returned value in `after` callback as the last argument.
+```ruby
+MyClass.after :two_arg_method do |args*, obj| result = args.last end
+```
+
 If you do not want to get a hold of the method arguments or the object, then you can just don't care about the block parameters :-)
 
 Check out the [getting a hold sample](https://github.com/PragTob/after_do/blob/master/samples/getting_a_hold.rb) for more.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install after_do
-    
+
 And then you have to require the gem before you can use it:
 
     require 'after_do'
@@ -99,6 +99,12 @@ Of course you can get a hold of the method arguments and the object:
 
 ```ruby
 MyClass.after :two_arg_method do |arg1, arg2, obj| something(arg1, arg2, obj) end
+```
+
+And finally if you want to access method name inside the callback:
+
+```ruby
+MyClass.after :two_arg_method do |arg1, arg2, obj, method| something(arg1, arg2, obj, method) end
 ```
 
 If you do not want to get a hold of the method arguments or the object, then you can just don't care about the block parameters :-)
@@ -174,7 +180,7 @@ after_do works with modules just like it works with classes from version 0.3.0 o
 class MyClass
   include MyModule
   # ....
-end 
+end
 
 MyModule.extend AfterDo
 MyModule.after :some_method do cool_stuff end

--- a/lib/after_do.rb
+++ b/lib/after_do.rb
@@ -97,7 +97,7 @@ module AfterDo
     define_method method do |*args|
       callback_klazz.send(:_after_do_execute_callbacks, :before, method, self, *args)
       return_value = send(alias_name, *args)
-      callback_klazz.send(:_after_do_execute_callbacks, :after, method, self, *args)
+      callback_klazz.send(:_after_do_execute_callbacks, :after, method, self, *args, return_value)
       return_value
     end
   end

--- a/lib/after_do.rb
+++ b/lib/after_do.rb
@@ -95,24 +95,32 @@ module AfterDo
   def _after_do_redefine_method_with_callback(method, alias_name)
     callback_klazz = self
     define_method method do |*args|
-      callback_klazz.send(:_after_do_execute_callbacks, :before, method, self, *args)
+      callback_klazz.send(:_after_do_execute_before_callbacks, method, self, *args)
       return_value = send(alias_name, *args)
-      callback_klazz.send(:_after_do_execute_callbacks, :after, method, self, *args, return_value)
+      callback_klazz.send(:_after_do_execute_after_callbacks, method, self, *args, return_value)
       return_value
     end
   end
 
-  def _after_do_execute_callbacks(type, method, object, *args)
-    @_after_do_callbacks[type][method].each do |block|
-      _after_do_execute_callback(block, method, object, *args)
+  def _after_do_execute_before_callbacks(method, object, *args)
+    _after_do_each_callback_wrapped(:before, method) do |callback|
+      callback.call(*args, object, method)
     end
   end
 
-  def _after_do_execute_callback(block, method, object, *args)
-    begin
-      block.call(*args, object, method)
-    rescue Exception => error
-      raise CallbackError, "A #{error.class}: #{error.message} was raised during an after_do callback block for method '#{method}' on the instance #{self.inspect} with the following arguments: #{args.join(', ')} defined in the file #{block.source_location[0]} in line #{block.source_location[1]}. This is the backtrace of the #{error.class}: \n #{error.backtrace.join("\n")}"
+  def _after_do_execute_after_callbacks(method, object, *args, return_value)
+    _after_do_each_callback_wrapped(:after, method) do |callback|
+      callback.call(*args, object, method, return_value)
+    end
+  end
+
+  def _after_do_each_callback_wrapped(type, method)
+    @_after_do_callbacks[type][method].each do |block|
+      begin
+        yield block
+      rescue Exception => error
+        raise CallbackError, "#{error.class}: #{error.message} raised during an after_do callback block for method '#{method}' on the instance #{self.inspect} defined in the file #{block.source_location[0]} in line #{block.source_location[1]}.\n This is the backtrace of the original error: \n #{error.backtrace.join("\n")}"
+      end
     end
   end
 end

--- a/lib/after_do.rb
+++ b/lib/after_do.rb
@@ -110,7 +110,7 @@ module AfterDo
 
   def _after_do_execute_callback(block, method, object, *args)
     begin
-      block.call(*args, object)
+      block.call(*args, object, method)
     rescue Exception => error
       raise CallbackError, "A #{error.class}: #{error.message} was raised during an after_do callback block for method '#{method}' on the instance #{self.inspect} with the following arguments: #{args.join(', ')} defined in the file #{block.source_location[0]} in line #{block.source_location[1]}. This is the backtrace of the #{error.class}: \n #{error.backtrace.join("\n")}"
     end

--- a/lib/after_do.rb
+++ b/lib/after_do.rb
@@ -104,13 +104,13 @@ module AfterDo
 
   def _after_do_execute_before_callbacks(method, object, *args)
     _after_do_each_callback_wrapped(:before, method) do |callback|
-      callback.call(*args, object, method)
+      callback.call(*args, method, object)
     end
   end
 
   def _after_do_execute_after_callbacks(method, object, *args, return_value)
     _after_do_each_callback_wrapped(:after, method) do |callback|
-      callback.call(*args, object, method, return_value)
+      callback.call(*args, method, return_value, object)
     end
   end
 

--- a/samples/getting_a_hold.rb
+++ b/samples/getting_a_hold.rb
@@ -2,15 +2,15 @@ require 'after_do'
 
 class Example
   def zero
-    # ...
+    0
   end
 
   def two(a, b)
-    # ...
+    a + b
   end
 
   def value
-    'some value'
+    'some_value'
   end
 end
 
@@ -19,31 +19,38 @@ Example.extend AfterDo
 Example.after :zero do puts 'Hello!' end
 
 # If the callback method takes no arguments then the first argument passed to
-# the block with will the instance of the class on which the original method
-# is called:
-Example.after :zero do |obj| puts obj.value end
+# the block with will the method name, then the return value and finally the object itself
+Example.after :zero do |_name, _return, obj| puts obj.value end
 
 # The method arguments are passed to the callback as well:
-Example.after :two do |first, second| puts first + ' ' + second end
+Example.after :two do |first, second| puts "#{first} #{second}" end
 
-# If the callback takes arguments, the last argument will be the instance of the
-# class:
-Example.after :two do |a, b, obj| puts a + ' ' + b + ' ' + obj.value end
+# Now alltogether:
+Example.after :two do |a, b, name, value, obj|
+  puts "after: #{a} #{b} #{name} #{value} #{obj.value}"
+end
+
+# Remember before can't get a return value as at that point the method hasn't
+# beene executed:
+Example.before :two do |a, b, name, obj|
+  puts "before: #{a} #{b} #{name} #{obj.value}"
+end
 
 # You can also use the * to soak up all the method arguments and get
 # straight to the instance:
-Example.after :two do |*args, obj|
+Example.after :two do |*args, _name, _return, obj|
   puts "args passed to callback: #{args.join(', ')}"
   puts 'just ' +  obj.value
 end
 
 e = Example.new
 e.zero
-e.two 'one', 'two'
+e.two 1, 2
 # prints:
 # Hello!
 # some value
-# one two
-# one two some value
-# args passed to callback: one, two
+# before: 1 2 two some_value
+# 1 2
+# after: 1 2 two 3 some_value
+# args passed to callback: 1, 2
 # just some value

--- a/samples/singleton.rb
+++ b/samples/singleton.rb
@@ -11,3 +11,9 @@ M.singleton_class.after :magic do puts 'after_do is pure magic' end
 
 M.magic
 M.magic
+
+# prints:
+# magic
+# after_do is pure magic
+# magic
+# after_do is pure magic

--- a/spec/after_do_spec.rb
+++ b/spec/after_do_spec.rb
@@ -21,7 +21,7 @@ describe AfterDo do
       end
 
       def two(param1, param2)
-        param2
+        param1 + param2
       end
     end
   end
@@ -223,6 +223,24 @@ describe AfterDo do
       end
     end
 
+    describe 'it can get a hold of the method name, if needbe' do
+      it 'works for a method without arguments' do
+        expect(mockie).to receive(:call_method).with(:zero)
+        @dummy_class.send callback_adder, :zero do |_object, method_name|
+          mockie.call_method(method_name)
+        end
+        dummy_instance.zero
+      end
+
+      it 'works for a method with arguments' do
+        expect(mockie).to receive(:call_method).with(1, 2, dummy_instance, :two)
+        @dummy_class.send callback_adder, :two do |arg1, arg2, object, method_name|
+          mockie.call_method(arg1, arg2, object, method_name)
+        end
+        dummy_instance.two(1, 2)
+      end
+    end
+
     describe 'inheritance' do
       let(:inherited_instance) {@inherited_class.new}
 
@@ -412,6 +430,16 @@ describe AfterDo do
       expect(callback).to receive(:before_call).ordered
       expect(callback).to receive(:after_call).ordered
       dummy_instance.zero
+    end
+  end
+
+  describe 'specific after behaviour' do
+    it 'also has access to the return value' do
+      expect(mockie).to receive(:call).with(10, 20, dummy_instance, :two, 30)
+      @dummy_class.after :two do |*args, inst, name, value|
+        mockie.call(args.first, args.last, inst, name, value)
+      end
+      dummy_instance.two 10, 20
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,7 @@
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatters = [Coveralls::SimpleCov::Formatter,
+                        SimpleCov::Formatter::HTMLFormatter]
 
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
Builds on #17 / deprecates it.

New argument order is: `arguments, method_name, (return_value), object`

Chose it like that so you can still ignore all method related things by just doing `|*, object|`. Might switch in the future to a more logical order (i.e. name, arguments, (return_value), object), but didn't want to be too breaking just yet.

What do you think @jarkadlec @chastell ?